### PR TITLE
fixed 修改本地测试时路径出错问题

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -13,7 +13,7 @@ import sys
 from jinja2 import Environment, FileSystemLoader
 from markdown import Markdown
 import pypinyin
-
+from settings import BASE_DIR
 
 # 静态文件路径，默认为`/static/`
 # 表示使用flask发布网站时的`http://ip:port/static/`目录
@@ -22,16 +22,16 @@ import pypinyin
 STATIC_ROOT = "/static/"
 
 # Markdown文件读取目录
-INPUT_CONTENT = "./in/"
+INPUT_CONTENT = os.path.join(BASE_DIR, "in")
 
 # 索引文件
-INDEX_DAT = "./static/out/index.dat"
+INDEX_DAT = os.path.join(BASE_DIR, "static", "out", "index.dat")
 
 # html生成输出目录
-OUTPUT_CONTENT = "./static/out/"
+OUTPUT_CONTENT = os.path.join(BASE_DIR, "static", "out")
 
 env = Environment(
-    loader=FileSystemLoader("templates")
+    loader=FileSystemLoader(os.path.join(BASE_DIR,"templates"))
 )
 
 PY_VERSION = "3" if sys.version >= "3" else "2"
@@ -55,7 +55,7 @@ TITLE_HTML_TEMPLATE = u"<div class='sidebar-module-inset'><h5 class='sidebar-tit
 
 
 def _reload_global():
-    global TAG_INVERTED_INDEX, AUTHOR_INVERTED_INDEX, ARTICLE_INDEX,\
+    global TAG_INVERTED_INDEX, AUTHOR_INVERTED_INDEX, ARTICLE_INDEX, \
         _MD_FILES, _current_file_index, _pinyin_names
 
     TAG_INVERTED_INDEX = {}

--- a/settings.py
+++ b/settings.py
@@ -2,8 +2,8 @@
 # -*- coding:utf-8 -*-
 
 """Documentation"""
-
-INDEX_DAT = "./static/out/index.dat"
+import os
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == "__main__":
     pass

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -4,7 +4,7 @@
 """Documentation"""
 import shelve
 
-from settings import INDEX_DAT
+from generate import INDEX_DAT
 
 
 class IndexData(object):


### PR DESCRIPTION
博客写得很棒，但是有一个问题，本地跑项目时经常报这个错，查验后是路径不对，已经修复，本地测试OK，提交 pull request 希望可以合并
```
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
127.0.0.1 - - [16/Jan/2018 13:44:18] "GET / HTTP/1.1" 200 -
127.0.0.1 - - [16/Jan/2018 13:44:19] "GET /tags/ HTTP/1.1" 200 -
[2018-01-16 13:44:19,609] ERROR in app: Exception on /api/index/inv_tag/ [GET]
Traceback (most recent call last):
  File "C:\Program Files\Python36\Lib\dbm\dumb.py", line 82, in _create
    f = _io.open(self._datfile, 'r', encoding="Latin-1")
FileNotFoundError: [Errno 2] No such file or directory: './static/out/index.dat.dat'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\_compat.py", line 33, in reraise
    raise value
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "C:\Users\Chen\.virtualenvs\flask-blog\lib\site-packages\flask\app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "C:\Users\Chen\PycharmProjects\blog-flask\api\views.py", line 28, in get_tag_index
    return jsonify(IndexData.get_index_data().get("tag_inverted_index"))
  File "C:\Users\Chen\PycharmProjects\blog-flask\utils\helper.py", line 30, in get_index_data
    cls._load_data()
  File "C:\Users\Chen\PycharmProjects\blog-flask\utils\helper.py", line 20, in _load_data
    dat = shelve.open(INDEX_DAT)
  File "C:\Program Files\Python36\Lib\shelve.py", line 243, in open
    return DbfilenameShelf(filename, flag, protocol, writeback)
  File "C:\Program Files\Python36\Lib\shelve.py", line 227, in __init__
    Shelf.__init__(self, dbm.open(filename, flag), protocol, writeback)
  File "C:\Program Files\Python36\Lib\dbm\__init__.py", line 94, in open
    return mod.open(file, flag, mode)
  File "C:\Program Files\Python36\Lib\dbm\dumb.py", line 324, in open
    return _Database(file, mode, flag=flag)
  File "C:\Program Files\Python36\Lib\dbm\dumb.py", line 70, in __init__
    self._create(flag)
  File "C:\Program Files\Python36\Lib\dbm\dumb.py", line 89, in _create
    with _io.open(self._datfile, 'w', encoding="Latin-1") as f:
FileNotFoundError: [Errno 2] No such file or directory: './static/out/index.dat.dat'
127.0.0.1 - - [16/Jan/2018 13:44:19] "GET /api/index/inv_tag/ HTTP/1.1" 500 -
127.0.0.1 - - [16/Jan/2018 13:44:19] "GET /tags/static/images/GitHub-Mark-32px.png HTTP/1.1" 404 -
```